### PR TITLE
Option to override the ruby s3cmd to the default python one

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/s3_copy.rb
+++ b/lib/capistrano/recipes/deploy/strategy/s3_copy.rb
@@ -33,16 +33,24 @@ module Capistrano
         def distribute!
           package_path = filename
           package_name = File.basename(package_path)
-          s3_push_cmd = "#{aws_environment} s3cmd put #{bucket_name}:#{rails_env}/#{package_name} #{package_path} x-amz-server-side-encryption:AES256 2>&1"
-
+          if bucket_override_url.nil?
+              s3_push_cmd = "#{aws_environment} s3cmd put #{bucket_name}:#{rails_env}/#{package_name} #{package_path} x-amz-server-side-encryption:AES256 2>&1"
+          else
+             s3_push_cmd = "#{aws_environment} s3cmd put #{package_path} #{bucket_override_url}/#{package_name} 2>&1"
+          end
+          
           if configuration.dry_run
             logger.debug s3_push_cmd
           else
             system(s3_push_cmd)
             raise Capistrano::Error, "shell command failed with return code #{$?}" if $? != 0
           end
-
-          run "#{aws_environment} s3cmd get #{bucket_name}:#{rails_env}/#{package_name} #{remote_filename} 2>&1"
+          
+          if bucket_override_url.nil?
+              run "#{aws_environment} s3cmd get #{bucket_name}:#{rails_env}/#{package_name} #{remote_filename} 2>&1"
+          else
+              run "#{aws_environment} s3cmd get #{bucket_override_url}/#{package_name} #{remote_filename} 2>&1"
+          end
           run "cd #{configuration[:releases_path]} && #{decompress(remote_filename).join(" ")} && rm #{remote_filename}"
           logger.debug "done!"
 
@@ -59,9 +67,15 @@ module Capistrano
           File.open(local_output_file, "w") do  |f|
             f.write(output)
           end
-          configuration[:s3_copy_aws_install_cmd] = "#{aws_environment} s3cmd put #{bucket_name}:#{rails_env}/aws_install.sh #{local_output_file} x-amz-server-side-encryption:AES256 2>&1"
+        
+          if bucket_override_url.nil?
+            configuration[:s3_copy_aws_install_cmd] = "#{aws_environment} s3cmd put #{bucket_name}:#{rails_env}/aws_install.sh #{local_output_file} x-amz-server-side-encryption:AES256 2>&1"
+          else
+            configuration[:s3_copy_aws_install_cmd] = "#{aws_environment} s3cmd put #{local_output_file} #{bucket_override_url}/aws_install.sh 2>&1"
+          end
+        
         end
-
+        
         def binding
           super
         end

--- a/lib/capistrano/recipes/deploy/strategy/s3_copy.rb
+++ b/lib/capistrano/recipes/deploy/strategy/s3_copy.rb
@@ -36,7 +36,7 @@ module Capistrano
           if bucket_override_url.nil?
               s3_push_cmd = "#{aws_environment} s3cmd put #{bucket_name}:#{rails_env}/#{package_name} #{package_path} x-amz-server-side-encryption:AES256 2>&1"
           else
-             s3_push_cmd = "#{aws_environment} s3cmd put #{package_path} #{bucket_override_url}/#{package_name} 2>&1"
+             s3_push_cmd = "s3cmd put #{package_path} #{bucket_override_url}/#{package_name} 2>&1"
           end
           
           if configuration.dry_run
@@ -49,7 +49,7 @@ module Capistrano
           if bucket_override_url.nil?
               run "#{aws_environment} s3cmd get #{bucket_name}:#{rails_env}/#{package_name} #{remote_filename} 2>&1"
           else
-              run "#{aws_environment} s3cmd get #{bucket_override_url}/#{package_name} #{remote_filename} 2>&1"
+              run "s3cmd get #{bucket_override_url}/#{package_name} #{remote_filename} 2>&1"
           end
           run "cd #{configuration[:releases_path]} && #{decompress(remote_filename).join(" ")} && rm #{remote_filename}"
           logger.debug "done!"
@@ -58,6 +58,7 @@ module Capistrano
         end
 
         def build_aws_install_script
+          logger.debug "Building installation script"
           template_text = configuration[:aws_install_script]
           template_text = File.read(File.join(File.dirname(__FILE__), "aws_install.sh.erb")) if template_text.nil?
           template_text = template_text.gsub("\r\n?", "\n")
@@ -71,8 +72,9 @@ module Capistrano
           if bucket_override_url.nil?
             configuration[:s3_copy_aws_install_cmd] = "#{aws_environment} s3cmd put #{bucket_name}:#{rails_env}/aws_install.sh #{local_output_file} x-amz-server-side-encryption:AES256 2>&1"
           else
-            configuration[:s3_copy_aws_install_cmd] = "#{aws_environment} s3cmd put #{local_output_file} #{bucket_override_url}/aws_install.sh 2>&1"
+            configuration[:s3_copy_aws_install_cmd] = "s3cmd put #{local_output_file} #{bucket_override_url}/aws_install.sh 2>&1"
           end
+          logger.debug "Installation script sent to S3"
         
         end
         


### PR DESCRIPTION
This change makes it possible to change set an arbitrary upload/download URL for the s3cmd command needed for the standard s3cmd program.
